### PR TITLE
#73: Convert CID to SQL statements

### DIFF
--- a/cutplace/applications.py
+++ b/cutplace/applications.py
@@ -25,6 +25,7 @@ from __future__ import unicode_literals
 
 import argparse
 import logging
+import io
 import os
 import sys
 
@@ -174,18 +175,7 @@ def process(argv=None):
         raise NotImplementedError
     elif cutplace_app.is_create_sql:
         cid_reader = interface.Cid()
-        cid_reader.read(cutplace_app.cid_path, rowio.excel_rows(cutplace_app.cid_path))
-
-        file_name = os.path.basename(cutplace_app.cid_path)
-        table_name = file_name.split('.')
-
-        outfile_name = table_name[0] + "_create.sql"
-
-        file = open(outfile_name, 'w')
-        file.write(sql.as_sql_create_table(cid_reader, sql.MYSQL))
-        file.close()
-
-        _log.info('write SQL-creates to "%s"', outfile_name)
+        sql.write_create(cutplace_app.cid_path, cid_reader)
     elif cutplace_app.data_paths:
         for data_path in cutplace_app.data_paths:
             try:

--- a/cutplace/sql.py
+++ b/cutplace/sql.py
@@ -20,11 +20,14 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import logging
+import io
 import os.path
 import sqlite3
 
 from cutplace import _tools
 from cutplace import ranges
+from cutplace import rowio
 
 # TODO: Move to module ``ranges``.
 MAX_SMALLINT = 2 ** 15 - 1
@@ -41,6 +44,8 @@ MSSQL = "mssql"
 MYSQL = "mysql"
 #: SQL dialect: Oracle
 ORACLE = "oracle"
+
+_log = logging.getLogger("cutplace")
 
 
 def assert_is_valid_dialect(dialect):
@@ -207,3 +212,15 @@ def as_sql_create_table(cid, dialect='ansi'):
             cursor.close()
 
     return result
+
+
+def write_create(cid_path, cid_reader):
+    cid_reader.read(cid_path, rowio.excel_rows(cid_path))
+
+    create_path = os.path.splitext(cid_path)[0] + '_create.sql'
+    # TODO: Add option to specify target folder for SQL files.
+    _log.info('write SQL create statements to "%s"', create_path)
+    with io.open(create_path, 'w', encoding='utf-8') as create_file:
+        # TODO: Add option for encoding.
+        create_file.write(as_sql_create_table(cid_reader, MYSQL))
+        # TODO: Add option for target SQL dialect


### PR DESCRIPTION
  * implemented a new command-line option so that the user is able to write the sql-create statements for a given cid into a sql-file (--create)